### PR TITLE
Relax steam peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "bytebuffer": ">=3.5.5"
   },
   "peerDependencies": {
-    "steam": "1.1.0"
+    "steam": ">=1.1.0 <2.0.0"
   },
-  "engines": { 
-    "node": ">0.12.9" 
+  "engines": {
+    "node": ">0.12.9"
   },
   "description": "A node-steam plugin for CS:GO.",
   "main": "index.js",


### PR DESCRIPTION
node-csgo should use the latest Steam module instead of v1.1.0 (Jul 30, 2015).
