### PR TITLE
update protoUpdate.js to include a required protobuf

### DIFF
--- a/protoUpdate.js
+++ b/protoUpdate.js
@@ -6,6 +6,7 @@ var path = require("path");
 var protos = [
 	"https://raw.githubusercontent.com/SteamDatabase/GameTracking/master/Protobufs/csgo/base_gcmessages.proto",
 	"https://raw.githubusercontent.com/SteamDatabase/GameTracking/master/Protobufs/csgo/cstrike15_gcmessages.proto",
+	"https://raw.githubusercontent.com/SteamDatabase/GameTracking/master/Protobufs/csgo/engine_gcmessages.proto",
 	"https://raw.githubusercontent.com/SteamDatabase/GameTracking/master/Protobufs/csgo/gcsdk_gcmessages.proto",
 	"https://raw.githubusercontent.com/SteamDatabase/GameTracking/master/Protobufs/csgo/steammessages.proto",
 	"https://raw.githubusercontent.com/SteamRE/SteamKit/master/Resources/Protobufs/steamclient/steammessages_clientserver.proto",


### PR DESCRIPTION
"https://raw.githubusercontent.com/SteamDatabase/GameTracking/master/Protobufs/csgo/engine_gcmessages.proto" is a new protobuf that is imported by cstrike15_gcmessages.proto

Not sure if the protobuf changes will bring any complications, but without this, `npm install` will fail because `protoUpdate.js` does not download all the required files.
