### PR TITLE
Fix incompatibility with future builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "csgo",
   "version": "1.4.1",
   "dependencies": {
-    "protobufjs": "*",
-    "deferred": "*",
+    "protobufjs": "^5.0.1",
+    "deferred": "^0.7.5",
     "bignumber.js": "^2.0.7",
     "bytebuffer": ">=3.5.5"
   },

--- a/protoUpdate.js
+++ b/protoUpdate.js
@@ -4,11 +4,11 @@ var url = require("url");
 var path = require("path");
 
 var protos = [
-	"https://raw.githubusercontent.com/SteamDatabase/GameTracking/master/Protobufs/csgo/base_gcmessages.proto",
-	"https://raw.githubusercontent.com/SteamDatabase/GameTracking/master/Protobufs/csgo/cstrike15_gcmessages.proto",
-	"https://raw.githubusercontent.com/SteamDatabase/GameTracking/master/Protobufs/csgo/engine_gcmessages.proto",
-	"https://raw.githubusercontent.com/SteamDatabase/GameTracking/master/Protobufs/csgo/gcsdk_gcmessages.proto",
-	"https://raw.githubusercontent.com/SteamDatabase/GameTracking/master/Protobufs/csgo/steammessages.proto",
+	"https://raw.githubusercontent.com/SteamDatabase/GameTracking-CSGO/master/Protobufs/base_gcmessages.proto",
+	"https://raw.githubusercontent.com/SteamDatabase/GameTracking-CSGO/master/Protobufs/cstrike15_gcmessages.proto",
+	"https://raw.githubusercontent.com/SteamDatabase/GameTracking-CSGO/master/Protobufs/engine_gcmessages.proto",
+	"https://raw.githubusercontent.com/SteamDatabase/GameTracking-CSGO/master/Protobufs/gcsdk_gcmessages.proto",
+	"https://raw.githubusercontent.com/SteamDatabase/GameTracking-CSGO/master/Protobufs/steammessages.proto",
 	"https://raw.githubusercontent.com/SteamRE/SteamKit/master/Resources/Protobufs/steamclient/steammessages_clientserver.proto",
 	"https://raw.githubusercontent.com/SteamRE/SteamKit/master/Resources/Protobufs/steamclient/steammessages_clientserver_2.proto",
 	"https://raw.githubusercontent.com/SteamRE/SteamKit/master/Resources/Protobufs/steamclient/steammessages_base.proto",


### PR DESCRIPTION
- Lock protobufjs version since v6 does not have method newBuilder and is a breaking change
- Use new resource links from SteamDatabase for the profobufs as they have refactored each game into its own repo