### PR TITLE
Handles GC Connection Becoming `undefined` During `_sendClientHello`

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ var CSGOClient = function CSGOClient(steamUser, steamGC, debug) {
     else if (!self._gc._connection) {
       util.log("GC Connection went missing, exiting");
 
-      this._gcReady = false;
+      self._gcReady = false;
 
       if (self._gcClientHelloIntervalId) {
         clearInterval(self._gcClientHelloIntervalId);

--- a/index.js
+++ b/index.js
@@ -64,6 +64,18 @@ var CSGOClient = function CSGOClient(steamUser, steamGC, debug) {
     if (!self._gc) {
       util.log("GC went missing");
     }
+    else if (!self._gc._connection) {
+      util.log("GC Connection went missing, exiting");
+
+      this._gcReady = false;
+
+      if (self._gcClientHelloIntervalId) {
+        clearInterval(self._gcClientHelloIntervalId);
+        self._gcClientHelloIntervalId = null;
+      }
+
+      self.emit("unready");
+    }
     else {
       self._gc.send({msg: CSGO.EGCBaseClientMsg.k_EMsgGCClientHello, proto: {}},
           new protos.CMsgClientHello({}).toBuffer());


### PR DESCRIPTION
Clears `_gcClientHelloIntervalId` and emits an `unready` event when the GC connection becomes undefined in `_sendClientHello`.

This can get triggered during unstable Steam connections on launch, or another user logging into the same account and launching CSGO at the same time as you are.