### PR TITLE
MAJOR: Fixes #45 _connection reference

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ var CSGOClient = function CSGOClient(steamUser, steamGC, debug) {
     if (!self._gc) {
       util.log("GC went missing");
     }
-    else if (!self._gc._connection) {
+    else if (!self._gc._client || !self._gc._client._connection) {
       util.log("GC Connection went missing, exiting");
 
       self._gcReady = false;


### PR DESCRIPTION
#45 had an improper reference to the SteamClient `_connection`, this fixes it. As a result, #45 would fail to launch in a normal login circumstance since `_connection` was `undefined`.